### PR TITLE
Add ISO8601 as a dependency

### DIFF
--- a/opam
+++ b/opam
@@ -33,6 +33,7 @@ depends: [
     "lwt-zmq"
     "nocrypto"
     "hex"
+    "ISO8601"
 ]
 depopts: [
 ]


### PR DESCRIPTION
This fixes the opam file, adding a necessary dependency that was not listed. 