### PR TITLE
Say this is no OCaml Jupyter kernel; point to some

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # Jupyter-Kernel
 
-A library for writing [jupyter](https://jupyter.org) kernels in OCaml
-
+A library for writing [Jupyter](https://jupyter.org) kernels in OCaml
 
 ## Install a Kernel
 
 ```sh
 jupyter kernelspec install dir/containing/kernel/ --user --replace --name=<name>
 ```
+
+## Related work
+
+This project is a library for *writing Jupyter kernels in OCaml*.
+
+If you are looking for a *Jupyter kernel for OCaml*, try one of these:
+- https://github.com/KKostya/simple_jucaml
+- https://github.com/andrewray/iocaml
+- https://github.com/akabe/ocaml-jupyter


### PR DESCRIPTION
Update the README to clarify this is no OCaml Jupyter kernel,
and point to some existing OCaml Jupyter kernels since people
searching for one are likely to land on this repo (cf #6).