### PR TITLE
Add codemirror_mode to language_info in kernel info response

### DIFF
--- a/src/Client.ml
+++ b/src/Client.ml
@@ -74,6 +74,7 @@ module Kernel = struct
     banner: string option; (* displayed at startup *)
     file_extension: string;
     mime_type: string option; (* default: text/plain *)
+    codemirror_mode: string option;
     complete: pos:int -> string -> completion_status Lwt.t;
     inspect: inspect_request -> inspect_reply_ok or_error Lwt.t;
     history: history_request -> string list Lwt.t;
@@ -83,6 +84,7 @@ module Kernel = struct
       ?banner
       ?(file_extension=".txt")
       ?mime_type
+      ?codemirror_mode
       ?(init=fun () -> Lwt.return_unit)
       ?(is_complete=fun _ -> Lwt.return Is_complete)
       ?(complete=fun ~pos i->
@@ -94,7 +96,7 @@ module Kernel = struct
       ~exec
       () : t =
     { banner; file_extension; mime_type; language; language_version;
-      is_complete; history; exec; complete; inspect; init;
+      is_complete; history; exec; complete; inspect; init; codemirror_mode
     }
 end
 
@@ -283,6 +285,7 @@ let kernel_info_request (t:t) ~parent =
             | None -> "text"
           );
           li_file_extension=t.kernel.Kernel.file_extension;
+          li_codemirror_mode=t.kernel.Kernel.codemirror_mode;
         };
         banner= (match t.kernel.Kernel.banner with
           | None -> ""

--- a/src/Client.mli
+++ b/src/Client.mli
@@ -71,6 +71,7 @@ module Kernel : sig
     banner: string option; (* displayed at startup *)
     file_extension: string;
     mime_type: string option; (* default: text/plain *)
+    codemirror_mode: string option; (* client side syntax highlighting mode *)
     complete: pos:int -> string -> completion_status Lwt.t;
     inspect: inspect_request -> inspect_reply_ok or_error Lwt.t;
     history: history_request -> string list Lwt.t;
@@ -80,6 +81,7 @@ module Kernel : sig
     ?banner:string ->
     ?file_extension:string ->
     ?mime_type:string ->
+    ?codemirror_mode:string ->
     ?init:(unit -> unit Lwt.t) ->
     ?is_complete:(string -> is_complete_reply Lwt.t) ->
     ?complete:(pos:int -> string -> completion_status Lwt.t) ->

--- a/src/Protocol.atd
+++ b/src/Protocol.atd
@@ -164,6 +164,7 @@ type language_info = {
   li_version <json name="version">: string; (* a.b.c *)
   li_mimetype <json name="mimetype">: string;
   li_file_extension <json name="file_extension">: string;
+  ?li_codemirror_mode <json name="codemirror_mode">: string option;
 }
 
 type help_link = {


### PR DESCRIPTION
This adds the `codemirror_mode` (nested under `language_info`) in the `kernel_info` response, which is used to pick the client-side syntax highlighting mode.

Without this new notebooks do not know which mode to use without it being manually specified in a notebook's metadata.