### PR TITLE
Split main into init / arg parse phase and main loop

### DIFF
--- a/src/Client_main.ml
+++ b/src/Client_main.ml
@@ -94,7 +94,7 @@ let rec main_loop connection_info kernel =
     Log.log "Dying.\n";
     Lwt.fail Exit
 
-let main ?(args=[]) ~usage kernel =
+let main ?(args=[]) ?post_init ~usage kernel =
   let args = mk_args ~args () in
   Arg.parse
     args
@@ -102,6 +102,15 @@ let main ?(args=[]) ~usage kernel =
     usage;
   let connection_info = mk_connection_info () in
   let%lwt() = Lwt_io.printf "Starting kernel for `%s`\n" kernel.C.Kernel.language in
+
+  begin
+    match post_init with
+    | None -> Lwt.return ()
+    | Some f ->
+      Log.log "Running post_init...\n";
+      f ()
+  end;
+
   Log.log "start main...\n";
   main_loop connection_info kernel >|= fun () ->
   Log.log "client_main: exiting\n"

--- a/src/Client_main.mli
+++ b/src/Client_main.mli
@@ -3,6 +3,7 @@
 
 val main :
   ?args:(Arg.key * Arg.spec * Arg.doc) list ->
+  ?post_init:(unit -> unit Lwt.t) ->
   usage:string ->
   Client.Kernel.t ->
   unit Lwt.t
@@ -14,5 +15,6 @@ val main :
     - Individual connection parameters with [--ci-<foo> <bar>];
     - See [--help] for more details;
     - The parameter [args] can contain additional command line arguments.
+    - The parameter [post_init] will be run after arg parse but before the main loop.
 *)
 


### PR DESCRIPTION
This allows a kernel specific init phase to run after arg parsing (using any custom args it may have passed in with `args`), _before_ the main loop gets under way.