### PR TITLE
Expose restart exception

### DIFF
--- a/src/Client.mli
+++ b/src/Client.mli
@@ -16,6 +16,8 @@ type mime_data = {
 (* list of mime objects, all of distinct types *)
 type mime_data_bundle = mime_data list
 
+exception Restart
+
 (** {2 User-Defined Kernel} *)
 module Kernel : sig
   type exec_action =

--- a/src/jbuild
+++ b/src/jbuild
@@ -3,7 +3,7 @@
   ((name jupyter_kernel)
    (public_name jupyter-kernel)
    (libraries (result atdgen yojson uuidm ZMQ lwt-zmq
-               nocrypto hex lwt lwt.unix lwt.preemptive threads
+               nocrypto hex lwt lwt.unix threads
                lwt_ppx bytes uutf ISO8601))
    (flags (:standard -safe-string -w +a-4-44@8))
    (preprocess (pps (lwt_ppx)))


### PR DESCRIPTION
I wanted to trigger a restart from my kernel code during exception. `Exit` is already available, but `Restart` is not  so this exposes it, hopefully this is the way it was intended and I'm not abusing things!

I also removed the `lwt.preemptive` module which seems to have gone (merged into `lwt.unix` iirc?)