### PR TITLE
Header username and session can't be missing in jupyterlab

### DIFF
--- a/src/Message.ml
+++ b/src/Message.ml
@@ -242,7 +242,7 @@ let make ~parent ~msg_type content = {
 }
 
 let empty_header : header_info = {
-  version = ""; date=""; username=""; msg_type=""; msg_id = ""; session="";
+  version = ""; date=""; username=(Some ""); msg_type=""; msg_id = ""; session=(Some "");
 }
 
 let mk_header msg_type : header_info = {

--- a/src/Protocol.atd
+++ b/src/Protocol.atd
@@ -27,8 +27,8 @@ type connection_info = {
 type header_info = {
     ~date : string;
     ~version: string;
-    ~username : string;
-    ~session : string;
+    ?username : string option;
+    ?session : string option;
     ~msg_id : string;
     ~msg_type : string;
 }


### PR DESCRIPTION
For labelled fields, the atdgenned code removes fields with empty string in by default.

The jupyter notebook interface doesnt mind this but the newer jupyterlab interface expects these fields to always be present, even if the value is empty string.

Unfortunately making the header fields non-optional doesnt work as sometime the old interface doesnt send them, so this breaks de-serialisation!

Ideally some kind of message format versioning would be the solution here but this does the job in the interim.