### PR TITLE
Remove post_init and create kernel via callback

### DIFF
--- a/src/Client_main.ml
+++ b/src/Client_main.ml
@@ -92,22 +92,15 @@ let main_loop connection_info kernel =
     Log.log "Dying.\n";
     Lwt.fail Exit
 
-let main ?(args=[]) ?post_init ~usage kernel =
+let main ?(args=[]) ~usage ~kernel_init =
   let args = mk_args ~args () in
   Arg.parse
     args
     (fun s -> failwith ("invalid anonymous argument: " ^ s))
     usage;
   let connection_info = mk_connection_info () in
+  let%lwt kernel = kernel_init () in
   let%lwt() = Lwt_io.printf "Starting kernel for `%s`\n" kernel.C.Kernel.language in
-
-  let%lwt() = match post_init with
-    | None -> Lwt.return ()
-    | Some f ->
-      Log.log "Running post_init...\n";
-      f ()
-  in
-
   Log.log "start main...\n";
   main_loop connection_info kernel >|= fun () ->
   Log.log "client_main: exiting\n"

--- a/src/Client_main.mli
+++ b/src/Client_main.mli
@@ -3,18 +3,16 @@
 
 val main :
   ?args:(Arg.key * Arg.spec * Arg.doc) list ->
-  ?post_init:(unit -> unit Lwt.t) ->
   usage:string ->
-  Client.Kernel.t ->
+  kernel_init:(unit -> Client.Kernel.t Lwt.t) ->
   unit Lwt.t
-(** [main ~usage kernel] will parse command line arguments, open a connection
-    using {!Sockets}, and run the [kernel].
+(** [main ~usage kernel_init] will parse command line arguments, open a connection
+    using {!Sockets}, and call the [init_kernel] function and run the returned kernel.
 
     - A connection file can be passed using [--connection-file <file>];
     - A log file through [--log <file>];
     - Individual connection parameters with [--ci-<foo> <bar>];
     - See [--help] for more details;
     - The parameter [args] can contain additional command line arguments.
-    - The parameter [post_init] will be run after arg parse but before the main loop.
 *)
 


### PR DESCRIPTION
This removes the `post_init` arg to `main` and instead changes the sig so `main` is passed a function that returns the kernel, rather than being passed the kernel directly.

This function lets post init stuff happen in it too, and allows the parsed CLI args to control params of the kernel more easily.