### PR TITLE
Init main split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ qtest*
 *.html
 .merlin
 *.install
+_opam/

--- a/src/Client_main.ml
+++ b/src/Client_main.ml
@@ -24,9 +24,9 @@ let ci_control = ref 50004
 let ci_transport = ref "tcp"
 let ci_ip_addr = ref ""
 
-let mk_args ~args () =
+let mk_args ~additional_args () =
   Arg.(align
-      (args @
+      (additional_args @
          [
            "--log", String (Log.open_log_file), " <file> open log file";
            "--connection-file", Set_string(connection_file_name),
@@ -92,15 +92,18 @@ let main_loop connection_info kernel =
     Log.log "Dying.\n";
     Lwt.fail Exit
 
-let main ?(args=[]) ~usage ~kernel_init =
-  let args = mk_args ~args () in
+type config = { connection_info: Proto_j.connection_info }
+
+let mk_config ?(additional_args=[]) ~usage () : config =
+  let args = mk_args ~additional_args () in
   Arg.parse
     args
     (fun s -> failwith ("invalid anonymous argument: " ^ s))
     usage;
-  let connection_info = mk_connection_info () in
-  let%lwt kernel = kernel_init () in
+  { connection_info = mk_connection_info () }
+
+let main ~(config : config) ~kernel =
   let%lwt() = Lwt_io.printf "Starting kernel for `%s`\n" kernel.C.Kernel.language in
   Log.log "start main...\n";
-  main_loop connection_info kernel >|= fun () ->
+  main_loop config.connection_info kernel >|= fun () ->
   Log.log "client_main: exiting\n"

--- a/src/Client_main.mli
+++ b/src/Client_main.mli
@@ -1,18 +1,23 @@
 
 (* This file is free software. See file "license" for more details. *)
 
-val main :
-  ?args:(Arg.key * Arg.spec * Arg.doc) list ->
+type config
+
+val mk_config :
+  ?additional_args:(Arg.key * Arg.spec * Arg.doc) list ->
   usage:string ->
-  kernel_init:(unit -> Client.Kernel.t Lwt.t) ->
-  unit Lwt.t
-(** [main ~usage kernel_init] will parse command line arguments, open a connection
-    using {!Sockets}, and call the [init_kernel] function and run the returned kernel.
+  unit ->
+  config
+(** [mk_config ?additional_args ~usage] will parse command line arguments and
+returns a config object to be consumed by {!main}.
 
     - A connection file can be passed using [--connection-file <file>];
     - A log file through [--log <file>];
     - Individual connection parameters with [--ci-<foo> <bar>];
     - See [--help] for more details;
-    - The parameter [args] can contain additional command line arguments.
+    - The parameter [additional_args] can contain additional command line arguments.
 *)
 
+val main : config:config -> kernel:Client.Kernel.t -> unit Lwt.t
+(** [main ~config ~kernel] will open a connection using {!Sockets}, and run the passed
+kernel. Run via {!Lwt_main.run} *)


### PR DESCRIPTION
This splits up the init / arg parsing phase from the 'main' phase, which gives the caller a lot more control.

For example if the kernel needs to create some kind of resource, parameterised by the command line arguments that it uses in both the initialisation and main loop, the caller can achieve that with this split version, whereas previously it was more challenging, e.g.

```ocaml
Client_main.init ~usage:"Example";
with_some_resource ~params:value_from_arg_parsing (fun x ->
  Lwt_main.run (Client_main.main ~kernel:(
    mk_kernel ~params:value_from_arg_parsing ~other:stuff_using_resource))
);
```

whereas without the split, it's hard to get the values into the resource wrapper:

```ocaml
with_some_resource ~params:VALUE_NOT_YET_PARSED (fun x ->
  Lwt_main.run (Client_main.main ~kernel_init:(fun () -> do_init_with_resource; mk_kernel))
)
```